### PR TITLE
testInteraction should report SEs

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+2023-12-01 Helios De Rosario-Martinez <helios.derosario@gmail.com>
+
+* R/testInteractions.R (testInteractions): add SE to tables (ctb. Phil Chalmers)
+
 2015-08-18 Helios De Rosario-Martinez <helios.derosario@gmail.com>
 
 * man, R: clarify that std. errors reported in testFactors and interactionMeans

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,11 +1,12 @@
 Package: phia
-Version: 0.2-1
-Date: 2015-08-18
+Version: 0.2-2
+Date: 2023-12-01
 Title: Post-Hoc Interaction Analysis
 Authors@R: c(person("Helios", "De Rosario-Martinez", role=c("aut", "cre"), 
 	email="helios.derosario@gmail.com"), 
 	person("John", "Fox", role="ctb"), 
-	person("R Core Team", role="ctb"))
+	person("R Core Team", role="ctb"),
+	person("Chalmers", "Phil", role="ctb"))
 Description: Analysis of terms in linear, generalized and mixed linear models, 
 	on the basis of multiple comparisons of factor contrasts.  Specially suited 
 	for the analysis of interaction terms.

--- a/R/testInteractions.R
+++ b/R/testInteractions.R
@@ -102,7 +102,9 @@ testInteractions <- function(model, pairwise=NULL, fixed=NULL, residual=NULL, ac
 		# and attach them to the anova table
 		adjusted.values <- summary(test)$adjusted.values[[1]]
 		if (nrow(test.table <- summary(test)$anova.table) == 0) stop(test$terms[[1]]$test)
-		anova.table <- rbind(anova.table,c(as.numeric(adjusted.values),unlist(test.table[1,])))
+		anova.table <- rbind(anova.table,c(as.numeric(adjusted.values),
+		                                   c(SE=unname(unlist(summary(test)$std.error)),
+		                                     unlist(test.table[1,]))))
 	}
 	# Adjust p-values
 	nc <- ncol(anova.table)


### PR DESCRIPTION
Greetings,

The following pull-request adds standard error estimates for the reported contrast estimates in the output whenever, for instance, `testInteractions()` is used. The behaviour is more consistent with what the `emmeans` package output contains for the same output, and should be useful in research reports that include contrast estimates. Here's an example of the output before and after.

```r
library(phia)

mod.boik <- aov(edr ~ therapy * medication, data=Boik)
testInteractions(mod.boik)

F Test: 
P-value adjustment method: holm
                           Value Df Sum of Sq       F    Pr(>F)    
control-T1 : placebo-D1  -8.9975  1    121.43  6.3411 0.1448291    
control-T2 : placebo-D1  -3.8985  1     22.80  1.1905 0.6951907    
     T1-T2 : placebo-D1   5.0990  1     39.00  2.0365 0.6951907    
control-T1 : placebo-D2 -17.1985  1    443.68 23.1687 0.0001563 ***
control-T2 : placebo-D2  -4.9984  1     37.48  1.9569 0.6951907    
     T1-T2 : placebo-D2  12.2002  1    223.27 11.6587 0.0149653 *  
control-T1 : placebo-D3 -28.5994  1   1226.89 64.0665 8.678e-10 ***
control-T2 : placebo-D3 -10.6990  1    171.70  8.9661 0.0439050 *  
     T1-T2 : placebo-D3  17.9004  1    480.63 25.0981 8.163e-05 ***
control-T1 :      D1-D2  -8.2010  1    100.88  5.2681 0.2270868    
control-T2 :      D1-D2  -1.0999  1      1.81  0.0948 0.7592877    
     T1-T2 :      D1-D2   7.1012  1     75.64  3.9498 0.4115755    
control-T1 :      D1-D3 -19.6019  1    576.35 30.0962 1.479e-05 ***
control-T2 :      D1-D3  -6.8005  1     69.37  3.6224 0.4326396    
     T1-T2 :      D1-D3  12.8013  1    245.81 12.8360 0.0095516 ** 
control-T1 :      D2-D3 -11.4008  1    194.97 10.1810 0.0270962 *  
control-T2 :      D2-D3  -5.7007  1     48.75  2.5455 0.6951907    
     T1-T2 :      D2-D3   5.7002  1     48.74  2.5450 0.6951907    
Residuals                        60   1149.01                      
---
Signif. codes:  0 ‘***’ 0.001 ‘**’ 0.01 ‘*’ 0.05 ‘.’ 0.1 ‘ ’ 1
```

After pull-request code:

```r
testInteractions(mod.boik)
F Test: 
P-value adjustment method: holm
                           Value     SE   Df Sum of Sq       F    Pr(>F)    
control-T1 : placebo-D1  -8.9975  3.573    1    121.43  6.3411 0.1448291    
control-T2 : placebo-D1  -3.8985  3.573    1     22.80  1.1905 0.6951907    
     T1-T2 : placebo-D1   5.0990  3.573    1     39.00  2.0365 0.6951907    
control-T1 : placebo-D2 -17.1985  3.573    1    443.68 23.1687 0.0001563 ***
control-T2 : placebo-D2  -4.9984  3.573    1     37.48  1.9569 0.6951907    
     T1-T2 : placebo-D2  12.2002  3.573    1    223.27 11.6587 0.0149653 *  
control-T1 : placebo-D3 -28.5994  3.573    1   1226.89 64.0665 8.678e-10 ***
control-T2 : placebo-D3 -10.6990  3.573    1    171.70  8.9661 0.0439050 *  
     T1-T2 : placebo-D3  17.9004  3.573    1    480.63 25.0981 8.163e-05 ***
control-T1 :      D1-D2  -8.2010  3.573    1    100.88  5.2681 0.2270868    
control-T2 :      D1-D2  -1.0999  3.573    1      1.81  0.0948 0.7592877    
     T1-T2 :      D1-D2   7.1012  3.573    1     75.64  3.9498 0.4115755    
control-T1 :      D1-D3 -19.6019  3.573    1    576.35 30.0962 1.479e-05 ***
control-T2 :      D1-D3  -6.8005  3.573    1     69.37  3.6224 0.4326396    
     T1-T2 :      D1-D3  12.8013  3.573    1    245.81 12.8360 0.0095516 ** 
control-T1 :      D2-D3 -11.4008  3.573    1    194.97 10.1810 0.0270962 *  
control-T2 :      D2-D3  -5.7007  3.573    1     48.75  2.5455 0.6951907    
     T1-T2 :      D2-D3   5.7002  3.573    1     48.74  2.5450 0.6951907    
Residuals                        60.000 1149                                
---
Signif. codes:  0 ‘***’ 0.001 ‘**’ 0.01 ‘*’ 0.05 ‘.’ 0.1 ‘ ’ 1
```

This also affects other input components where presenting the marginal/conditional information should also include SEs

```r
> testInteractions(mod.boik, across = "therapy") # same as summary(mod.boik)
F Test: 
P-value adjustment method: holm
          therapy1 therapy2    SE1     SE2 Df Sum of Sq      F    Pr(>F)    
Mean        9.4002  -4.5995  1.263    1.26  2    2444.1 63.813 1.399e-15 ***
Residuals                   60.000 1149.01                                  
---
Signif. codes:  0 ‘***’ 0.001 ‘**’ 0.01 ‘*’ 0.05 ‘.’ 0.1 ‘ ’ 1
> testInteractions(mod.boik, pairwise = "therapy")
F Test: 
P-value adjustment method: holm
             Value     SE   Df Sum of Sq       F    Pr(>F)    
control-T1 13.9997  1.263    1   2351.89 122.813 1.136e-15 ***
control-T2  9.4002  1.263    1   1060.35  55.370 8.829e-10 ***
     T1-T2 -4.5995  1.263    1    253.87  13.257 0.0005675 ***
Residuals          60.000 1149                                
---
Signif. codes:  0 ‘***’ 0.001 ‘**’ 0.01 ‘*’ 0.05 ‘.’ 0.1 ‘ ’ 1

```


There may be other opportunities to add support for confidence intervals (e.g., via a `confint()` generic), but that is not included in this pull. Let me know if you have any other questions or require the pull to be modified in some way. Cheers.